### PR TITLE
(doc) Corrected markdown formatting

### DIFF
--- a/minio-server/minio-server.nuspec
+++ b/minio-server/minio-server.nuspec
@@ -18,26 +18,25 @@
     <tags>minio-server distributed file storage server</tags>
     <summary>Minio is a distributed object storage server, written in Go and open sourced under Apache License Version 2.0</summary>
     <description>
-    # Minio is a distributed object storage server, written in Go and open sourced under Apache License Version 2.0
+# Minio is a distributed object storage server, written in Go and open sourced under Apache License Version 2.0
     
-    ## Amazon S3 Compatible
-    Amazon S3 API is the de facto standard for object storage. Minio implements Amazon S3 v2/v4 API. Use Minio SDK, Minio Client, AWS SDK and AWS CLI to access Minio server.
+## Amazon S3 Compatible
+Amazon S3 API is the de facto standard for object storage. Minio implements Amazon S3 v2/v4 API. Use Minio SDK, Minio Client, AWS SDK and AWS CLI to access Minio server.
 
-    ## Data Protection
-    Minio protects data against hardware failures using erasure code and bitrot detection. You may lose up to half the number of drives and still recover from it. Data protection code is accelerated using SIMD instructions on x64 and ARM CPUs.
+## Data Protection
+Minio protects data against hardware failures using erasure code and bitrot detection. You may lose up to half the number of drives and still recover from it. Data protection code is accelerated using SIMD instructions on x64 and ARM CPUs.
 
-    ## Highly Available
-    Minio server can tolerate up to (N/2)-1 node failures in a distributed setup. In addition, you may configure Minio server to continuously mirror data between Minio and any Amazon S3 compatible server.
+## Highly Available
+Minio server can tolerate up to (N/2)-1 node failures in a distributed setup. In addition, you may configure Minio server to continuously mirror data between Minio and any Amazon S3 compatible server.
 
-    ## Lambda Compute
-    Minio server triggers Lambda functions through its AWS SNS/SQS compatible event notification service. Supported targets are message queues such as Kafka, NATS, AMQP, MQTT, Webhooks, and databases such as Elasticsearch, Redis, Postgres, and MySQL. Thumbnail generation, OCR and audit compliance are good examples of lambda computing.
+## Lambda Compute
+Minio server triggers Lambda functions through its AWS SNS/SQS compatible event notification service. Supported targets are message queues such as Kafka, NATS, AMQP, MQTT, Webhooks, and databases such as Elasticsearch, Redis, Postgres, and MySQL. Thumbnail generation, OCR and audit compliance are good examples of lambda computing.
 
-    ## Encryption and Tamper-Proof
-    Minio provides confidentiality, integrity and authenticity assurances for encrypted data with negligible performance overhead. Both server side and client side encryption are supported using AES-256-GCM, ChaCha20-Poly1305 and AES-CBC. Encrypted objects are tamper-proofed with AEAD server side encryption.
+## Encryption and Tamper-Proof
+Minio provides confidentiality, integrity and authenticity assurances for encrypted data with negligible performance overhead. Both server side and client side encryption are supported using AES-256-GCM, ChaCha20-Poly1305 and AES-CBC. Encrypted objects are tamper-proofed with AEAD server side encryption.
 
-    ## Pluggable Storage Backend
-    In addition to Minio's own filesystem and erasure code backends for DAS and JBODs, external storage backends such as NAS, Google Cloud Storage, and Azure Blob Storage are supported as well.
-    
+## Pluggable Storage Backend
+In addition to Minio's own filesystem and erasure code backends for DAS and JBODs, external storage backends such as NAS, Google Cloud Storage, and Azure Blob Storage are supported as well.    
     </description>
   </metadata>
   <files>


### PR DESCRIPTION
In order for markdown to show correctly on the site, it needs to begin at the start of the line.