### PR TITLE
Adjust name of install client executable.

### DIFF
--- a/minio-client/tools/chocolateyinstall.ps1
+++ b/minio-client/tools/chocolateyinstall.ps1
@@ -7,8 +7,8 @@ $packageArgs = @{
   unzipLocation   = $toolsDir
   fileType        = 'EXE'
   url64bit        = $url64
-  FileFullPath    = "$toolsDir\minio.exe"
-  softwareName    = 'minio-server*'
+  FileFullPath    = "$toolsDir\mc.exe"
+  softwareName    = 'minio-client*'
 
   checksum64    = '3beb2b6e9ecb5a0ddaeb5c88b02ee34ce7c1a28c5380cd391ec93f162bb091ca'
   checksumType64  = 'sha256'


### PR DESCRIPTION
Ensure that Minio client is installed as `mc.exe` in order to maintain consistency with executable name provided by Minio and avoid potential collision with the Minio server's executable.