### PR TITLE
Update chocolateyinstall.ps1

### DIFF
--- a/usbdlm/tools/chocolateyinstall.ps1
+++ b/usbdlm/tools/chocolateyinstall.ps1
@@ -13,9 +13,9 @@ $packageArgs = @{
 
   softwareName  = 'usbdlm*'
 
-  checksum      = 'f4a26ccea65f5577818ed5be60a7ac297092fa0f6dce396619bb0d706d18c76f'
+  checksum      = '2d42257af32d72cd5c4552a9777dac22ef9fb82cb3d295602688e6bee4b400ac'
   checksumType  = 'sha256'
-  checksum64    = 'da9425bfa50bb124623bf1eaac146f9ffa1fc888dd71fc6c491f8cb4769ea9e6'
+  checksum64    = '7545284b0f63a1bc0e780895677faf13d2f68341da72e83c10d7ae67303ce4e8'
   checksumType64= 'sha256'
 
   silentArgs    = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""


### PR DESCRIPTION
Replaced checksums for version 5.4.10 as this package automatically downloads and installs the latest version (currently 5.4.11) and the checksums here are outdated.