### PR TITLE
Replaced checksums and version number in nuspec file for version 5.5.…

### DIFF
--- a/usbdlm/tools/chocolateyinstall.ps1
+++ b/usbdlm/tools/chocolateyinstall.ps1
@@ -13,9 +13,9 @@ $packageArgs = @{
 
   softwareName  = 'usbdlm*'
 
-  checksum      = '0ce62f66d944bf856dfbf2b646afee131f5faa92b0b83fc9a87ea571e613f8fd'
+  checksum      = '2af65646ef5b4cb99652cac9dde056b50861c39b4830d52defd30ceecbfdfbb4'
   checksumType  = 'sha256'
-  checksum64    = '27e13443eb6c1bc23ab4c072e776bfa94f44f48e0621e4d8471cfc03938147b1'
+  checksum64    = '63108a45765b30e277f45cf074ec88635d992bb6ebadc5fb227338c5f767f976'
   checksumType64= 'sha256'
 
   silentArgs    = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""

--- a/usbdlm/usbdlm.nuspec
+++ b/usbdlm/usbdlm.nuspec
@@ -26,7 +26,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-    <version>5.5.0</version>
+    <version>5.5.1</version>
     <packageSourceUrl>https://github.com/elpatron68/my-chocolatey-packages</packageSourceUrl>
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
     <owners>elpatron</owners>


### PR DESCRIPTION
USBDLM 5.5.1 has been released on 07/11 so the nuspec version number and checksums had to be updated in the source files of the USBDLM Chocolatey package. The current usbdlm Chocolatey package results in a checksum error when you try to install it.